### PR TITLE
Fix CSV2JSON compatibility with Mac

### DIFF
--- a/tool/CSV2JSON.py
+++ b/tool/CSV2JSON.py
@@ -6,8 +6,13 @@ import os
 import csv
 import json
 
-csv_file_path = sys.argv[1]
-output_dir = os.path.dirname(csv_file_path)
+def find_csv_in_directory(directory):
+    for file_name in os.listdir(directory):
+        if file_name.endswith('.csv'):
+            return os.path.join(directory, file_name)
+    return None
+output_dir = os.path.dirname(os.path.abspath(__file__))
+csv_file_path = find_csv_in_directory(output_dir)
 
 def process_row(row):
     locales = {}

--- a/tool/run_on_mac.command
+++ b/tool/run_on_mac.command
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+VAR1=`dirname "${BASH_SOURCE[0]}"`
+VAR2="/CSV2JSON.py"
+echo $VAR1$VAR2
+python3 $VAR1$VAR2


### PR DESCRIPTION
Drag n drop method doesn't work on OSX.
So I made another way to get a path to CSV, and also added a bash file, to make running CSV2JSON easier for Unix users